### PR TITLE
优化寻找PDF附件的逻辑

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -24,18 +24,11 @@ class AddonPreview extends AddonBase {
     if (items.length !== 1) {
       return false;
     }
-    let item: ZoteroItem;
-    if (items[0].isPDFAttachment()) {
-      item = items[0];
-    } else if (items[0].isRegularItem()) {
-      const attachment = (
-        Zotero.Items.get(items[0].getAttachments()) as ZoteroItem[]
-      ).find((att) => att.isPDFAttachment());
-      if (attachment) {
-        item = attachment;
-      }
-    }
-    if (!item) {
+    let item: ZoteroItem = items[0];
+    if (item.isRegularItem())
+      item = await items[0].getBestAttachment();
+    
+    if (!item.isPDFAttachment()) {
       this._Addon.events.setSplitCollapsed(true, true);
       return false;
     } else {


### PR DESCRIPTION
` item.getBestAttachment();`会优先寻找匹配URI的PDF附件

```js
/**
 * Looks for attachment in the following order: oldest PDF attachment matching parent URL,
 * oldest non-PDF attachment matching parent URL, oldest PDF attachment not matching URL,
 * old non-PDF attachment not matching URL
 *
 * @return {Promise<Zotero.Item|FALSE>} - A promise for attachment item or FALSE if none
 */
Zotero.Item.prototype.getBestAttachment = Zotero.Promise.coroutine(function* () {
	if (!this.isRegularItem()) {
		throw ("getBestAttachment() can only be called on regular items");
	}
	var attachments = yield this.getBestAttachments();
	return attachments ? attachments[0] : false;
});
```