### PR TITLE
fix viewer layout

### DIFF
--- a/addon/chrome/content/previewPDF.html
+++ b/addon/chrome/content/previewPDF.html
@@ -27,7 +27,7 @@
       }
       #viewerContainer {
         display: block;
-        height: calc(100% - 32px);
+        height: inherit;
         overflow-y: scroll;
       }
       .viewerCanvas {
@@ -126,6 +126,7 @@
       var zoomTime = 0;
 
       function updateToolbar(previewType) {
+        const viewerContainer = document.getElementById("viewerContainer");
         const toolbar = document.querySelector(".toolbar");
         const showToolbar =
           ((previewType === 1 || previewType === 3) &&
@@ -133,6 +134,7 @@
           (previewType === 2 && Zotero.Prefs.get("pdfpreview.showToolInTab"));
         toolbar.style.visibility = showToolbar ? "visible" : "hidden";
         toolbar.style.height = showToolbar ? "32px" : "0";
+        viewerContainer.style.height = showToolbar ? "calc(100% - 32px)" : "inherit";
       }
 
       function getScale() {

--- a/addon/chrome/content/previewPDF.html
+++ b/addon/chrome/content/previewPDF.html
@@ -27,7 +27,7 @@
       }
       #viewerContainer {
         display: block;
-        height: inherit;
+        height: calc(100% - 32px);
         overflow-y: scroll;
       }
       .viewerCanvas {


### PR DESCRIPTION
Due to the toolbar has a 32px height, the height of `#viewerContainer` must shrink by 32px from inherited `100%`.